### PR TITLE
Added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
+WORKDIR /app
+EXPOSE 5000
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore "TinfoilWebServer/TinfoilWebServer.csproj"
+WORKDIR "/src/TinfoilWebServer"
+RUN dotnet build "TinfoilWebServer.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "TinfoilWebServer.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+RUN chown app:app /app
+USER app
+RUN mkdir -p /app/config
+ENTRYPOINT ["dotnet", "TinfoilWebServer.dll", "-d", "/app/config"]


### PR DESCRIPTION
Created a very basic Dockerfile, it could very sure be improved.
Config directory can be mounted to `/app/config` for ease of use

Doesn't require complicated cli lines

To test it:
`docker build -t tinfoilwebserver:latest .`
`docker run --rm tinfoilwebserver:latest`

A custom config can be mounted like this:
`docker run --rm -v /path/to/your/config:/app/config tinfoilwebserver:latest`

Hope this helps
If you need any changes to this pls say so and I'll see how to do it.